### PR TITLE
[Feature] Reading 4d series and reorient scan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Project Specific
+data/
+
 # Mac system
 .DS_Store
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ visualdl
 sklearn
 filelock
 nibabel
+pydicom

--- a/tools/prepare.py
+++ b/tools/prepare.py
@@ -43,7 +43,7 @@ from tools.preprocess_utils import uncompressor, global_var, add_qform_sform
 
 class Prep:
     def __init__(self, dataset_root="data/TemDataSet", raw_dataset_dir="TemDataSet_seg_raw/",
-                 images_dir="train_imgs", labels_dir="train_labels", phase_dir="phase0", 
+                 images_dir="train_imgs", labels_dir="train_labels", phase_dir="phase0",
                  urls=None, valid_suffix=("nii.gz", "nii.gz"), filter_key=(None, None),
                  uncompress_params={"format": "zip", "num_files": 1}):
         """
@@ -52,7 +52,7 @@ class Prep:
             dataset_root
             ├── raw_dataset_dir
             │   ├── image_dir
-            │   ├── labels_dir  
+            │   ├── labels_dir
             ├── phase_dir
             │   ├── images
             │   ├── labels
@@ -77,9 +77,9 @@ class Prep:
         os.makedirs(self.image_path, exist_ok=True)
         os.makedirs(self.label_path, exist_ok=True)
         self.gpu_tag = "GPU" if global_var.get_value('USE_GPU') else "CPU"
-        
-        # self.uncompress_file(num_files=uncompress_params["num_files"], form=uncompress_params["format"])
-        
+
+        self.uncompress_file(num_files=uncompress_params["num_files"], form=uncompress_params["format"])
+
         # Load the needed file with filter
         self.image_files = get_image_list(self.image_dir, valid_suffix[0], filter_key[0])
         self.label_files = get_image_list(self.label_dir, valid_suffix[1], filter_key[1])
@@ -130,11 +130,10 @@ class Prep:
         """
         print("Start convert images to numpy array using {}, please wait patiently"
             .format(self.gpu_tag))
-        
-        time1 = time.time()
-        with open(self.dataset_json_path, 'r', encoding='utf-8') as f:
-            dataset_json_dict=json.load(f) 
 
+        tic = time.time()
+        with open(self.dataset_json_path, 'r', encoding='utf-8') as f:
+            dataset_json_dict=json.load(f)
         for i, files in enumerate((self.image_files, self.label_files)):
             pre = self.preprocess[["images", "labels"][i]]
             savepath = (self.image_path, self.label_path)[i]
@@ -143,7 +142,7 @@ class Prep:
                 f_np = Prep.load_medical_data(f)
 
                 for op in pre:
-                    if op.__name__ == "resample": 
+                    if op.__name__ == "resample":
                         spacing = dataset_json_dict["training"][f.split("/")[-1].split(".")[0]]["spacing"] if i==0 else None
                         f_np, new_spacing = op(f_np, spacing=spacing)
                     else:
@@ -151,15 +150,15 @@ class Prep:
 
                 if i == 0:
                     dataset_json_dict["training"][f.split("/")[-1].split(".")[0]]["spacing_resample"] = new_spacing
-                
+
                 f_np = f_np.astype("float32") if i==0 else f_np.astype("int32")
                 np.save(os.path.join(savepath, f.split("/")[-1].split(".", maxsplit=1)[0]), f_np)
-        
+
         with open(self.dataset_json_path, 'w', encoding='utf-8') as f:
             json.dump(dataset_json_dict, f, ensure_ascii=False, indent=4)
 
         print("The preprocess time on {} is {}".format(self.gpu_tag,
-                                                    time.time() - time1))
+                                                    time.time() - tic))
 
     def convert_path(self):
         """convert nii.gz file to numpy array in the right directory"""
@@ -181,7 +180,7 @@ class Prep:
         # plt.subplot(1,2,1),plt.xticks([]),plt.yticks([]),plt.imshow(imga)
         # plt.subplot(1,2,2),plt.xticks([]),plt.yticks([]),plt.imshow(imgb)
         # plt.show()
-    
+
     @staticmethod
     def write_txt(txt, image_names, label_names=None):
         """
@@ -267,7 +266,7 @@ class Prep:
         :param labels: dict with int->str (key->value) mapping the label IDs to label names. Note that 0 is always
         supposed to be background! Example: {0: 'background', 1: 'edema', 2: 'enhancing tumor'}
         :param dataset_name: The name of the dataset. Can be anything you want
-        :param license_desc: 
+        :param license_desc:
         :param dataset_description:
         :param dataset_reference: website of the dataset, if available
         :return:
@@ -299,15 +298,15 @@ class Prep:
             infor_dict["origin"] = img_itk.GetOrigin()
             infor_dict["direction"] = img_itk.GetDirection()
             json_dict['training'][image_name.split("/")[-1].split(".")[0]] = infor_dict
-            
-        json_dict['test'] = []                 
+
+        json_dict['test'] = []
 
 
         if not self.dataset_json_path.endswith("dataset.json"):
             print("WARNING: output file name is not dataset.json! This may be intentional or not. You decide. "
                 "Proceeding anyways...")
-        else: 
+        else:
             print("save dataset.json to {}".format(self.dataset_json_path))
-        
+
         with open(self.dataset_json_path, 'w', encoding='utf-8') as f:
             json.dump(json_dict, f, ensure_ascii=False, indent=4)


### PR DESCRIPTION
1. 增加读取4d序列支持，load_medical_data返回一个列表，里面每个元素是一个3d序列的numpy数组
2. 增加体位矫正
3. 用sitk读nii的结果固定是xyz，应该没有pr 50里提到的[问题](https://github.com/PaddleCV-SIG/MedicalSeg/pull/50#discussion_r837281553)

目前4D image + 3D label 的数据预处理只会用到 4D 图像的第一个3D volume。这块是想 pr 51 决定预处理那个wrapper要不要用之后再修改预处理部分。3D图像的行为和之前是一致的。

带上了清空格的commit，所有修改都在最后一个commit。我看是可以 [只看一个commit的修改](https://github.com/PaddleCV-SIG/MedicalSeg/pull/52/commits/04775d3cba040afd21d42baa8b7dc9d2b3e75f43)